### PR TITLE
feat: Add "GetProjectAsync()" alias

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,13 +14,14 @@ For each alias, multiple overloads are available, see [Overloads](./overloads.md
 |----------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | Helpers        | `GitLabTryGetCurrentServerIdentity()`  | Attempts to determine the server identity from environment variables (see [Identity and Connection objects](identites-and-connection-objects.md))  | 
 |                | `GitLabTryGetCurrentProjectIdentity()` | Attempts to determine the project identity from environment variables (see [Identity and Connection objects](identites-and-connection-objects.md)) | 
-| Pipelines      | `GitLabGetPipelineAsync()`             | Gets data about a GitLab CI pipeline                                                                                                               |
-|                | `GitLabSetPipelineNameAsync()`         | Updates the name of a pipeline                                                                                                                     |
-|                | `GitLabGetPipelineJobsAsync()`         | Get the jobs for a pipeline.                                                                                                                       |
+| Projects       | `GitLabGetProjectAsync()`              | Gets information about a specific project                                                                                                          |
 | Repository     | `GitLabRepositoryDownloadFileAsync()`  | Downloads a file from a GitLab-hosted repository                                                                                                   |
 |                | `GitLabRepositoryGetBranchesAsync()`   | Lists all of a project's branches                                                                                                                  |
 |                | `GitLabRepositoryCreateTagAsync()`     | Creates a new tag in the project repository                                                                                                        |
 | Merge Requests | `GitLabGetMergeRequestsAsync()`        | Gets the Merge Requests for a project                                                                                                              |
+| Pipelines      | `GitLabGetPipelineAsync()`             | Gets data about a GitLab CI pipeline                                                                                                               |
+|                | `GitLabSetPipelineNameAsync()`         | Updates the name of a pipeline                                                                                                                     |
+|                | `GitLabGetPipelineJobsAsync()`         | Get the jobs for a pipeline.                                                                                                                       |
 
 ## Additional Information
 

--- a/docs/mdsource/README.source.md
+++ b/docs/mdsource/README.source.md
@@ -7,13 +7,14 @@ For each alias, multiple overloads are available, see [Overloads](./overloads.md
 |----------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | Helpers        | `GitLabTryGetCurrentServerIdentity()`  | Attempts to determine the server identity from environment variables (see [Identity and Connection objects](identites-and-connection-objects.md))  | 
 |                | `GitLabTryGetCurrentProjectIdentity()` | Attempts to determine the project identity from environment variables (see [Identity and Connection objects](identites-and-connection-objects.md)) | 
-| Pipelines      | `GitLabGetPipelineAsync()`             | Gets data about a GitLab CI pipeline                                                                                                               |
-|                | `GitLabSetPipelineNameAsync()`         | Updates the name of a pipeline                                                                                                                     |
-|                | `GitLabGetPipelineJobsAsync()`         | Get the jobs for a pipeline.                                                                                                                       |
+| Projects       | `GitLabGetProjectAsync()`              | Gets information about a specific project                                                                                                          |
 | Repository     | `GitLabRepositoryDownloadFileAsync()`  | Downloads a file from a GitLab-hosted repository                                                                                                   |
 |                | `GitLabRepositoryGetBranchesAsync()`   | Lists all of a project's branches                                                                                                                  |
 |                | `GitLabRepositoryCreateTagAsync()`     | Creates a new tag in the project repository                                                                                                        |
 | Merge Requests | `GitLabGetMergeRequestsAsync()`        | Gets the Merge Requests for a project                                                                                                              |
+| Pipelines      | `GitLabGetPipelineAsync()`             | Gets data about a GitLab CI pipeline                                                                                                               |
+|                | `GitLabSetPipelineNameAsync()`         | Updates the name of a pipeline                                                                                                                     |
+|                | `GitLabGetPipelineJobsAsync()`         | Get the jobs for a pipeline.                                                                                                                       |
 
 ## Additional Information
 

--- a/src/Cake.GitLab/_Aliases/GitLabAliases.Projects.cs
+++ b/src/Cake.GitLab/_Aliases/GitLabAliases.Projects.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Cake.Core;
+using Cake.Core.Annotations;
+using NGitLab.Models;
+
+namespace Cake.GitLab;
+
+public static partial class GitLabAliases
+{
+    /// <summary>
+    /// Gets information about a specific project
+    /// </summary>
+    /// <param name="context">The current Cake context</param>
+    /// <param name="serverUrl">The url of the GitLab server</param>
+    /// <param name="accessToken">The access token for authenticating to the GitLab server</param>
+    /// <param name="project">The path (name and namespace) or id of the project to get</param>
+    /// <seealso href="https://docs.gitlab.com/ee/api/projects.html#get-a-single-project">Get a single project (GitLab Docs)</seealso>
+    [CakeMethodAlias]
+    [CakeAliasCategory("Projects")]
+    public static async Task<Project> GitLabGetProjectAsync(this ICakeContext context, string serverUrl, string accessToken, ProjectId project) =>
+        await context.GetGitLabProvider().GetProjectAsync(serverUrl, accessToken, project);
+}

--- a/src/Cake.GitLab/_Implementation/DefaultGitLabProvider.Projects.cs
+++ b/src/Cake.GitLab/_Implementation/DefaultGitLabProvider.Projects.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using NGitLab;
+using NGitLab.Models;
+
+namespace Cake.GitLab;
+
+public partial class DefaultGitLabProvider
+{
+    /// <inheritdoc />
+    public async Task<Project> GetProjectAsync(string serverUrl, string accessToken, ProjectId project)
+    {
+        var log = GetLogForCurrentOperation();
+        log.Verbose($"Getting GitLab project {project}");
+
+        var client = GetClient(serverUrl, accessToken);
+
+        try
+        {
+            var projectData = await client.Projects.GetAsync(project);
+            return projectData;
+        }
+        catch (GitLabException ex)
+        {
+            throw new CakeException($"Error while getting GitLab project {project}: {ex.Message}", ex);
+        }
+    }
+}

--- a/src/Cake.GitLab/_Implementation/IGitLabProvider.cs
+++ b/src/Cake.GitLab/_Implementation/IGitLabProvider.cs
@@ -55,4 +55,9 @@ public interface IGitLabProvider
     /// Implements the functionality of <see cref="GitLabAliases.GitLabGetMergeRequestsAsync(ICakeContext,string,string,ProjectId,GetMergeRequestsOptions)"/>
     /// </summary>
     Task<IReadOnlyCollection<MergeRequest>> GetMergeRequestsAsync(string serverUrl, string accessToken, ProjectId project, GetMergeRequestsOptions? options);
+
+    /// <summary>
+    /// Implements the functionality of <see cref="GitLabAliases.GitLabGetProjectAsync(ICakeContext,string,string,ProjectId)"/>
+    /// </summary>
+    Task<Project> GetProjectAsync(string serverUrl, string accessToken, ProjectId project);
 }

--- a/test/Cake.GitLab.Test/PublicApi.verified.txt
+++ b/test/Cake.GitLab.Test/PublicApi.verified.txt
@@ -7,6 +7,7 @@
         public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.MergeRequest>> GetMergeRequestsAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, Cake.GitLab.GetMergeRequestsOptions? options) { }
         public System.Threading.Tasks.Task<NGitLab.Models.Pipeline> GetPipelineAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, long pipelineId) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.Job>> GetPipelineJobsAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, long pipelineId, Cake.GitLab.GetPipelineJobsOptions? options) { }
+        public System.Threading.Tasks.Task<NGitLab.Models.Project> GetProjectAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project) { }
         public System.Threading.Tasks.Task<NGitLab.Models.Tag> RepositoryCreateTagAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, string @ref, string name) { }
         public System.Threading.Tasks.Task RepositoryDownloadFileAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, string filePath, string @ref, Cake.Core.IO.FilePath destination) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.Branch>> RepositoryGetBranchesAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project) { }
@@ -76,6 +77,21 @@
         [Cake.Core.Annotations.CakeAliasCategory("Pipelines")]
         [Cake.Core.Annotations.CakeMethodAlias]
         public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.Job>> GitLabGetPipelineJobsAsync(this Cake.Core.ICakeContext context, string serverUrl, string accessToken, NGitLab.Models.ProjectId project, long pipelineId, Cake.GitLab.GetPipelineJobsOptions? options = null) { }
+        [Cake.Core.Annotations.CakeAliasCategory("Projects")]
+        [Cake.Core.Annotations.CakeMethodAlias]
+        public static System.Threading.Tasks.Task<NGitLab.Models.Project> GitLabGetProjectAsync(this Cake.Core.ICakeContext context, Cake.GitLab.ProjectConnection projectConnection) { }
+        [Cake.Core.Annotations.CakeAliasCategory("Projects")]
+        [Cake.Core.Annotations.CakeMethodAlias]
+        public static System.Threading.Tasks.Task<NGitLab.Models.Project> GitLabGetProjectAsync(this Cake.Core.ICakeContext context, Cake.GitLab.ProjectIdentity projectIdentity, string accessToken) { }
+        [Cake.Core.Annotations.CakeAliasCategory("Projects")]
+        [Cake.Core.Annotations.CakeMethodAlias]
+        public static System.Threading.Tasks.Task<NGitLab.Models.Project> GitLabGetProjectAsync(this Cake.Core.ICakeContext context, Cake.GitLab.ServerConnection serverConnection, NGitLab.Models.ProjectId project) { }
+        [Cake.Core.Annotations.CakeAliasCategory("Projects")]
+        [Cake.Core.Annotations.CakeMethodAlias]
+        public static System.Threading.Tasks.Task<NGitLab.Models.Project> GitLabGetProjectAsync(this Cake.Core.ICakeContext context, Cake.GitLab.ServerIdentity serverIdentity, string accessToken, NGitLab.Models.ProjectId project) { }
+        [Cake.Core.Annotations.CakeAliasCategory("Projects")]
+        [Cake.Core.Annotations.CakeMethodAlias]
+        public static System.Threading.Tasks.Task<NGitLab.Models.Project> GitLabGetProjectAsync(this Cake.Core.ICakeContext context, string serverUrl, string accessToken, NGitLab.Models.ProjectId project) { }
         [Cake.Core.Annotations.CakeAliasCategory("Repository")]
         [Cake.Core.Annotations.CakeMethodAlias]
         public static System.Threading.Tasks.Task<NGitLab.Models.Tag> GitLabRepositoryCreateTagAsync(this Cake.Core.ICakeContext context, Cake.GitLab.ProjectConnection projectConnection, string @ref, string name) { }
@@ -148,6 +164,7 @@
         System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.MergeRequest>> GetMergeRequestsAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, Cake.GitLab.GetMergeRequestsOptions? options);
         System.Threading.Tasks.Task<NGitLab.Models.Pipeline> GetPipelineAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, long pipelineId);
         System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.Job>> GetPipelineJobsAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, long pipelineId, Cake.GitLab.GetPipelineJobsOptions? options);
+        System.Threading.Tasks.Task<NGitLab.Models.Project> GetProjectAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project);
         System.Threading.Tasks.Task<NGitLab.Models.Tag> RepositoryCreateTagAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, string @ref, string name);
         System.Threading.Tasks.Task RepositoryDownloadFileAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project, string filePath, string @ref, Cake.Core.IO.FilePath destination);
         System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.Branch>> RepositoryGetBranchesAsync(string serverUrl, string accessToken, NGitLab.Models.ProjectId project);


### PR DESCRIPTION
Add alias "GetProjectAsync()" that allows retrieving information about a GitLab project.

See-Also: https://docs.gitlab.com/ee/api/projects.html#get-a-single-project
